### PR TITLE
adds make install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,3 +409,8 @@ if (DEFINED MALLOC_LIBRARY)
     endif()
 endif()
 
+# -----------------------------------------------------------------------------
+# installation
+# -----------------------------------------------------------------------------
+
+install(TARGETS w2rap-contigger hbv2gfa DESTINATION bin)


### PR DESCRIPTION
adds proper installation procedure via `make install`, e.g.:

```console
$ mkdir build
$ cd build
$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
$ make
$ sudo make install
...
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/bin/w2rap-contigger
-- Installing: /usr/bin/hbv2gfa
```

---

fixes #29